### PR TITLE
cmake: prefer system opencl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,11 +14,14 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 
-include_directories(include)
-include_directories(external/OpenCL/external/OpenCL-CLHPP/include)
-
-set(OPENCL_SDK_BUILD_SAMPLES OFF CACHE BOOL "" FORCE)
-add_subdirectory(external/OpenCL)
+find_package(OpenCLHeaders CONFIG)
+if (OpenCLHeaders_FOUND)
+    find_package(OpenCLHeadersCpp REQUIRED)
+    find_package(OpenCLICDLoader REQUIRED)
+else()
+    set(OPENCL_SDK_BUILD_SAMPLES OFF CACHE BOOL "" FORCE)
+    add_subdirectory(external/OpenCL)
+endif()
 
 add_subdirectory(src)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,9 +1,9 @@
 add_library(device_static STATIC device.cpp utils.cpp)
-target_link_libraries(device_static PUBLIC OpenCL::OpenCL)
+target_link_libraries(device_static PUBLIC OpenCL::HeadersCpp OpenCL::OpenCL)
 target_include_directories(device_static PUBLIC ${CMAKE_SOURCE_DIR}/include)
 
 add_library(device SHARED device.cpp utils.cpp)
-target_link_libraries(device PUBLIC OpenCL::OpenCL)
+target_link_libraries(device PUBLIC OpenCL::HeadersCpp OpenCL::OpenCL)
 target_include_directories(device PUBLIC ${CMAKE_SOURCE_DIR}/include)
 
 add_library(mcl:device ALIAS device)
@@ -12,11 +12,11 @@ add_library(mcl:device_static ALIAS device_static)
 file(GLOB SRC "*.cpp")
 
 add_library(miss-opencl_static STATIC ${SRC})
-target_link_libraries(miss-opencl_static PUBLIC OpenCL::OpenCL device_static)
+target_link_libraries(miss-opencl_static PUBLIC OpenCL::HeadersCpp OpenCL::OpenCL device_static)
 target_include_directories(miss-opencl_static PUBLIC ${CMAKE_SOURCE_DIR}/include)
 
 add_library(miss-opencl SHARED ${SRC})
-target_link_libraries(miss-opencl PUBLIC OpenCL::OpenCL device)
+target_link_libraries(miss-opencl PUBLIC OpenCL::HeadersCpp OpenCL::OpenCL device)
 target_include_directories(miss-opencl PUBLIC ${CMAKE_SOURCE_DIR}/include)
 
 add_library(mcl:opencl ALIAS miss-opencl)


### PR DESCRIPTION
If OpenCL headers are found on the system, require other components from the system too, otherwise build everything from the submodule.